### PR TITLE
feat: added game versioning to invalidate old saves

### DIFF
--- a/src/globals/Managers/SaveManager/game_state.gd
+++ b/src/globals/Managers/SaveManager/game_state.gd
@@ -20,6 +20,7 @@ enum Flag {
 @export var mission_states: Dictionary[String, MissionState] = {}
 @export var flags: Dictionary[Flag, bool] = {}
 @export var rng_seed: int = 0
+@export var version: int
 
 
 func _init():


### PR DESCRIPTION
Added game versions to invalidate old saves on breaking changes.
Manual version changes in SaveManager use this.

In future, could also potentially be used for migration rather than complete invalidation.